### PR TITLE
Add support for multiple platforms (skip if not Linux)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,229 @@
+# Copyright 2017 Red Hat, Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+galaxy_info:
+  author: Dominik Lenoch
+  description: Middleware Messaging - Quality Engineering
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: Apache
+
+  min_ansible_version: 1.2
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If travis integration is cofigured, only notification for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Below are all platforms currently available. Just uncomment
+  # the ones that apply to your role. If you don't see your
+  # platform on this list, let us know and we'll get it added!
+  #
+  platforms:
+  #- name: OpenBSD
+  #  versions:
+  #  - all
+  #  - 5.6
+  #  - 5.7
+  #  - 5.8
+  #  - 5.9
+  #  - 6.0
+  #- name: Fedora
+  #  versions:
+  #  - all
+  #  - 16
+  #  - 17
+  #  - 18
+  #  - 19
+  #  - 20
+  #  - 21
+  #  - 22
+  #  - 23
+  #  - 24
+  #  - 25
+  #- name: DellOS
+  #  versions:
+  #  - all
+  #  - 10
+  #  - 6
+  #  - 9
+  #- name: MacOSX
+  #  versions:
+  #  - all
+  #  - 10.10
+  #  - 10.11
+  #  - 10.12
+  #  - 10.7
+  #  - 10.8
+  #  - 10.9
+  #- name: Synology
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Junos
+  #  versions:
+  #  - all
+  #  - any
+  #- name: GenericBSD
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Void Linux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: GenericLinux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: NXOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: IOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Amazon
+  #  versions:
+  #  - all
+  #  - 2013.03
+  #  - 2013.09
+  #  - 2016.03
+  #  - 2016.09
+  #- name: ArchLinux
+  #  versions:
+  #  - all
+  #  - any
+  #- name: FreeBSD
+  #  versions:
+  #  - all
+  #  - 10.0
+  #  - 10.1
+  #  - 10.2
+  #  - 10.3
+  #  - 11.0
+  #  - 8.0
+  #  - 8.1
+  #  - 8.2
+  #  - 8.3
+  #  - 8.4
+  #  - 9.0
+  #  - 9.1
+  #  - 9.1
+  #  - 9.2
+  #  - 9.3
+  #- name: Ubuntu
+  #  versions:
+  #  - all
+  #  - lucid
+  #  - maverick
+  #  - natty
+  #  - oneiric
+  #  - precise
+  #  - quantal
+  #  - raring
+  #  - saucy
+  #  - trusty
+  #  - utopic
+  #  - vivid
+  #  - wily
+  #  - xenial
+  #  - yakkety
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - sid
+  #  - squeeze
+  #  - stretch
+  #  - wheezy
+  #- name: Alpine
+  #  versions:
+  #  - all
+  #  - any
+  - name: EL
+    versions:
+      - 6
+      - 7
+      - 8
+  #- name: Windows
+  #  versions:
+  #  - all
+  #  - 2012R2
+  #- name: SmartOS
+  #  versions:
+  #  - all
+  #  - any
+  #- name: opensuse
+  #  versions:
+  #  - all
+  #  - 12.1
+  #  - 12.2
+  #  - 12.3
+  #  - 13.1
+  #  - 13.2
+  #- name: SLES
+  #  versions:
+  #  - all
+  #  - 10SP3
+  #  - 10SP4
+  #  - 11
+  #  - 11SP1
+  #  - 11SP2
+  #  - 11SP3
+  #  - 11SP4
+  #  - 12
+  #  - 12SP1
+  #- name: GenericUNIX
+  #  versions:
+  #  - all
+  #  - any
+  #- name: Solaris
+  #  versions:
+  #  - all
+  #  - 10
+  #  - 11.0
+  #  - 11.1
+  #  - 11.2
+  #  - 11.3
+  #- name: eos
+  #  versions:
+  #  - all
+  #  - Any
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is
+    # a keyword that describes and categorizes the role.
+    # Users find roles by searching for tags. Be sure to
+    # remove the '[]' above if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of
+    # alphanumeric characters. Maximum 20 tags per role.

--- a/tasks/main_linux.yml
+++ b/tasks/main_linux.yml
@@ -13,6 +13,20 @@
 # limitations under the License.
 ---
 
-- name: Install broker on Linux machine
-  when: ansible_os_family == 'Linux'
-  include: main_linux.yml
+- name: Check
+  include: check.yml
+
+- name: Systemd service
+  include: systemd.yml
+  when: systemd_check.stat.exists == True
+
+- name: SysV service
+  include: sysv.yml
+  when: sysv_check.stat.exists == True and systemd_check.stat.exists == False
+
+# - name: Upstart
+#   include: upstart.yml
+#   when: upstart_check.stat.exists == True
+
+- name: Service posthook
+  include: posthook.yml

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -555,7 +555,7 @@ UtmpMode={{ item.value.UtmpMode }}
 {% endif -%}
 
 [Install]
-{% if item.value.WantedBy is defined %}
+{% if item.value.Alias is defined %}
 Alias={{ item.value.Alias }}
 {% endif -%}
 {% if item.value.WantedBy is defined %}


### PR DESCRIPTION
AMQ Service on windows is supported in a weird way. This role is not applicable imo to it.

One has to first download and create instance of AMQ 7. From that place, one will create a service, so this would effectively put dependency on AMQ7, which we don't want. So I am skipping this service role on Windows hosts.