### PR TITLE
Modified main condition for role which is skipping on RedHat VMs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,6 @@
 # limitations under the License.
 ---
 
-- name: Install broker on Linux machine
-  when: ansible_os_family == 'Linux'
+- name: Create service on Linux machine
+  when: ansible_system == 'Linux'
   include: main_linux.yml


### PR DESCRIPTION
- Role is not being executed on RHEL VM as ansible_os_family is
  currently 'RedHat' and not 'Linux'.
- Renamed main task.